### PR TITLE
Updated conda_compile

### DIFF
--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -1,6 +1,6 @@
 if [ ! -d /app/.heroku/miniconda ]; then
     puts-step "Preparing Python/Miniconda Environment (3.5.2)"
-    curl -Os http://repo.continuum.io/miniconda/Miniconda-3.7.3-Linux-x86_64.sh
+    curl -Os https://repo.continuum.io/miniconda/Miniconda-3.7.3-Linux-x86_64.sh
     bash Miniconda-3.7.3-Linux-x86_64.sh  -p /app/.heroku/miniconda/ -b | indent
     rm -fr Miniconda-3.7.3-Linux-x86_64.sh
 

--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -5,17 +5,20 @@ if [ ! -d /app/.heroku/miniconda ]; then
     rm -fr Miniconda-3.7.3-Linux-x86_64.sh
 
     conda install pip --yes | indent
+    conda clean -pt --yes > /dev/null
 fi
 
 
 if [ -f conda-requirements.txt ]; then
     puts-step "Installing dependencies using Conda"
     conda install --file conda-requirements.txt --yes | indent
+    conda clean -pt --yes > /dev/null
 fi
 
 if [ -f requirements.txt ]; then
     puts-step "Installing dependencies using Pip"
     pip install -r requirements.txt  --exists-action=w --allow-all-external | indent
+    conda clean -pt --yes > /dev/null
 fi
 
 # Clean up the installation environment .


### PR DESCRIPTION
The protocol of repo.continuum.io changed to HTTPS, so the URL needs to be updated (cf. Support INC0051925).  I also added `conda clean -pt --yes > /dev/null` steps earlier to minimize the disk footprint.